### PR TITLE
Feature/wait infraready and OIDC already exists

### DIFF
--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -90,6 +90,7 @@ type AWSManagedControlPlaneReconciler struct {
 	EnableIAM            bool
 	AllowAdditionalRoles bool
 	WatchFilterValue     string
+	WaitInfraPeriod      time.Duration
 	ExternalResourceGC   bool
 }
 
@@ -232,7 +233,7 @@ func (r *AWSManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, 
 		// Wait for the cluster infrastructure to be ready before creating machines
 		if !managedScope.Cluster.Status.InfrastructureReady {
 			managedScope.Info("Cluster infrastructure is not ready yet")
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: r.WaitInfraPeriod}, nil
 		}
 	}
 

--- a/pkg/cloud/services/eks/iam/iam.go
+++ b/pkg/cloud/services/eks/iam/iam.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
@@ -461,7 +462,7 @@ func (s *IAMService) FindAndVerifyOIDCProvider(cluster *eks.Cluster) (string, er
 			return "", errors.Wrap(err, "error getting provider")
 		}
 		// URL should always contain `https`.
-		if *provider.Url != issuerURL.String() {
+		if *provider.Url != issuerURL.String() && *provider.Url != strings.Replace(issuerURL.String(), "https://", "", 1) {
 			continue
 		}
 		if len(provider.ThumbprintList) != 1 || *provider.ThumbprintList[0] != thumbprint {


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Avoid "failed to create OIDC provider: error creating provider: EntityAlreadyExists" and "EKSControlPlaneReconciliationFailed" errors when provider.Url do not contain https

Provider infrastructure is not ready when AWS Managed Control Plane is reconciled for the first time and the cluster creation get stuck for 15 minutes until the reconciliation is forced.
